### PR TITLE
Add toml to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
+toml


### PR DESCRIPTION
We are seeing issues running assisted-swarm in CI on RHEL 8.4 due to the toml package not being installed. Including it in requirements.txt fixes it for us.